### PR TITLE
1.3.3 - fix color scheme: beige bg, white cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "subcloakify",
-    "version": "1.3.0",
+    "version": "1.3.3",
     "description": "subcloakify - a keycloak theme for subtype, for all",
     "repository": {
         "type": "git",

--- a/src/login/globals.css
+++ b/src/login/globals.css
@@ -5,17 +5,17 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: oklch(0.9398 0.0234 82.12);
+  --background: oklch(1 0 0);
   --foreground: oklch(0.1450 0 0);
-  --card: oklch(0.9398 0.0234 82.12);
+  --card: oklch(1 0 0);
   --card-foreground: oklch(0.1450 0 0);
-  --popover: oklch(0.9398 0.0234 82.12);
+  --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.1450 0 0);
   --primary: oklch(0.3647 0.0555 200.35);
   --primary-foreground: oklch(0.9398 0.0234 82.12);
   --secondary: oklch(0.3088 0.0018 106.5021);
   --secondary-foreground: oklch(0.9398 0.0234 82.12);
-  --muted: oklch(0.9700 0 0);
+  --muted: oklch(0.9398 0.0234 82.12);
   --muted-foreground: oklch(0.5560 0 0);
   --accent: oklch(0.9700 0 0);
   --accent-foreground: oklch(0.2050 0 0);


### PR DESCRIPTION
## Summary
- Fix color scheme: page background now uses beige (#F3EADA via `--muted`), cards restored to white
- Bump version to 1.3.3

## Test plan
- [ ] Verify beige background on login page
- [ ] Verify white card on login page
- [ ] CI passes and release is cut