### PR TITLE
1.4.0 - sharp corners, teal borders, Helvetica, editorial type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "subcloakify",
-    "version": "1.3.3",
+    "version": "1.4.0",
     "description": "subcloakify - a keycloak theme for subtype, for all",
     "repository": {
         "type": "git",

--- a/src/login/globals.css
+++ b/src/login/globals.css
@@ -28,8 +28,8 @@
   --warning-foreground: oklch(0.37 0.0087 219.71);
   --success: oklch(0.9559 0.0186 145.43);
   --success-foreground: oklch(0.5184 0.127 142.04);
-  --border: oklch(0.9220 0 0);
-  --input: oklch(0.9220 0 0);
+  --border: oklch(0.3647 0.0555 200.35);
+  --input: oklch(0.3647 0.0555 200.35);
   --ring: oklch(0.3647 0.0555 200.35);
   --chart-1: oklch(0.8100 0.1000 252);
   --chart-2: oklch(0.6200 0.1900 260);
@@ -44,18 +44,18 @@
   --sidebar-accent-foreground: oklch(0.2050 0 0);
   --sidebar-border: oklch(0.9220 0 0);
   --sidebar-ring: oklch(0.7080 0 0);
-  --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-sans: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   --font-serif: Roboto, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  --radius: 0.75rem;
-  --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
-  --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
-  --shadow-sm: 0 1px 3px 0px hsl(0 0% 0% / 0.10), 0 1px 2px -1px hsl(0 0% 0% / 0.10);
-  --shadow: 0 1px 3px 0px hsl(0 0% 0% / 0.10), 0 1px 2px -1px hsl(0 0% 0% / 0.10);
-  --shadow-md: 0 1px 3px 0px hsl(0 0% 0% / 0.10), 0 2px 4px -1px hsl(0 0% 0% / 0.10);
-  --shadow-lg: 0 1px 3px 0px hsl(0 0% 0% / 0.10), 0 4px 6px -1px hsl(0 0% 0% / 0.10);
-  --shadow-xl: 0 1px 3px 0px hsl(0 0% 0% / 0.10), 0 8px 10px -1px hsl(0 0% 0% / 0.10);
-  --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
+  --radius: 0rem;
+  --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.04);
+  --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.04);
+  --shadow-sm: 0 1px 4px 0px hsl(0 0% 0% / 0.06);
+  --shadow: 0 2px 8px 0px hsl(0 0% 0% / 0.06);
+  --shadow-md: 0 2px 8px 0px hsl(0 0% 0% / 0.06);
+  --shadow-lg: 0 4px 12px 0px hsl(0 0% 0% / 0.06);
+  --shadow-xl: 0 4px 16px 0px hsl(0 0% 0% / 0.07);
+  --shadow-2xl: 0 4px 20px 0px hsl(0 0% 0% / 0.07);
 }
 
 .dark {
@@ -97,7 +97,7 @@
   --sidebar-accent-foreground: oklch(0.9398 0.0234 82.12);
   --sidebar-border: oklch(0.2750 0 0);
   --sidebar-ring: oklch(0.4390 0 0);
-  --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-sans: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   --font-serif: Roboto, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   --radius: 0.75rem;
@@ -159,7 +159,7 @@
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  --radius-xl: var(--radius);
 
   --shadow-2xs: var(--shadow-2xs);
   --shadow-xs: var(--shadow-xs);

--- a/src/login/pages/Login.tsx
+++ b/src/login/pages/Login.tsx
@@ -19,8 +19,8 @@ const providerLogos = useProviderLogos();
 const header = () => {
     return (
         <CardHeader>
-            <CardTitle id="card-title">Welcome back</CardTitle>
-            <CardDescription id="card-description">Login with your email or a provider below</CardDescription>
+            <CardTitle id="card-title" className="uppercase font-black tracking-tight">Welcome back</CardTitle>
+            <CardDescription id="card-description" className="uppercase text-xs tracking-widest font-medium">Login with your email or a provider below</CardDescription>
         </CardHeader>
     );
 };


### PR DESCRIPTION
## Summary
- `--radius: 0rem` — sharp corners across all components
- `--border` + `--input` → teal for on-brand input/card borders
- `--font-sans` → Helvetica Neue stack
- Lightened all shadows (card reads as document panel, not floating bubble)
- `CardTitle` — uppercase font-black tracking-tight
- `CardDescription` — uppercase small-caps tracking treatment
- Fixed `--radius-xl` in `@theme inline` so Card's hardcoded `rounded-xl` doesn't override global 0

## Test plan
- [ ] Login page: cream background, white card, teal borders, sharp corners, Helvetica, heavy uppercase title
- [ ] CI passes and v1.4.0 release is cut